### PR TITLE
Limit width for query

### DIFF
--- a/rails/app/assets/stylesheets/application.css.scss
+++ b/rails/app/assets/stylesheets/application.css.scss
@@ -115,6 +115,7 @@ body {
           float: left;
           line-height: 30px;
           margin: -5px 0;
+          max-width: 600px;
           a {
             font-size: 20px;
             text-align: center;


### PR DESCRIPTION
### 概要

長いクエリが投げられた時に、横スクロール可能になってしまうので回避
